### PR TITLE
Use 'active file' rotation method, add prune options

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,7 @@
 name: Rust
 on:
   push:
-    branches: [ main, hotfix/* ]
+    branches: [ main, hotfix/*, feature/* ]
   pull_request:
     branches: [ main, release/* ]
 env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turnstiles"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Graeme Gossel <graeme.gossel@gmail.com>"]
 description = "Seamless file rotation"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Implemented/planned rotation conditions:
 This is currently in active development and may change/break often. Every effort will be taken to ensure that breaking changes that occur are reflected in a change of at least the minor version of the package, both in terms of the API and the generation of log files. Versions prior to 0.2.0 were so riddled with bugs I'm amazed I managed to put my pants on on those days I was writing it.
 
 ## Note:
-Library which defines a struct implementing the io::Write trait which will allows file rotation, if applicable, when a file write is done. This works by keeping track
-of the 'active' file, the one currently being written to, which upon rotation is renamed to include the next log file index. For example when there is only one log file it will be `test_ACTIVE.log`, which when rotated will get renamed to `test.log.1` and the `test_ACTIVE.log` will represent a new file being written to. Originally no file renaming was done to keep the surface area with the filesystem as small as possible, however this has a few disadvantages and this active-file-approach (courtesy of [flex-logger](https://docs.rs/flexi_logger/latest/flexi_logger/)) was seen as a good compromise.
+Rotation works by keeping track of the 'active' file, the one currently being written to, which upon rotation is renamed to include the next log file index. For example when there is only one log file it will be `test_ACTIVE.log`, which when rotated will get renamed to `test.log.1` and the `test_ACTIVE.log` will represent a new file being written to. Originally no file renaming was done to keep the surface area with the filesystem as small as possible, however this has a few disadvantages and this active-file-approach (courtesy of [flex-logger](https://docs.rs/flexi_logger/latest/flexi_logger/)) was seen as a good compromise.
 
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Implemented/planned rotation conditions:
 - [x] Duration (time since last modified)
 - [ ] SizeLines (number of lines in file) 
 
+There are also three options to prune old logs:
+- [x] None
+- [x] MaxFiles
+- [x] MaxAge
+
 ## Warning:
 This is currently in active development and may change/break often. Every effort will be taken to ensure that breaking changes that occur are reflected in a change of at least the minor version of the package, both in terms of the API and the generation of log files. Versions prior to 0.2.0 were so riddled with bugs I'm amazed I managed to put my pants on on those days I was writing it.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,12 @@ use utils::{filename_to_details, safe_unwrap_osstr};
 
 // TODO: template this maybe? Or just make it u128 and fugheddaboutit?
 type FileIndexInt = u32;
+const ACTIVE_PREFIX: &'static str = "ACTIVE_";
 #[derive(Debug)]
 /// Struct masquerades as a file handle and is written to by whatever you like
 pub struct RotatingFile {
     filename_root: String,
+
     rotation: RotationOption,
     current_file: File,
     index: FileIndexInt,
@@ -104,13 +106,9 @@ impl RotatingFile {
     pub fn new(path_str: &str, rotation: RotationOption, require_newline: bool) -> Result<Self> {
         // TODO: throw error if path_str (rootname) ends in digit as this will break the numbering stuff
         let (path_filename, parent) = filename_to_details(path_str)?;
-        let current_index = Self::detect_latest_file_index(&path_filename, &parent)?;
-        let current_filename = if current_index != 0 {
-            format!("{}.{}", path_filename, current_index)
-        } else {
-            path_filename
-        };
-        let current_file_path = format!("{}/{}", parent, current_filename);
+        let current_index = Self::detect_latest_file_index(&path_filename, &parent)? + 1;
+        let current_file_path = format!("{}/{}{}", parent, ACTIVE_PREFIX, path_filename);
+        dbg!(&current_file_path);
         let file = OpenOptions::new()
             .create(true)
             .write(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ const ACTIVE_PREFIX: &'static str = "ACTIVE_";
 /// Struct masquerades as a file handle and is written to by whatever you like
 pub struct RotatingFile {
     filename_root: String,
-    parent: String,
     active_file_path: String,
     rotation: RotationOption,
     current_file: File,
@@ -117,7 +116,6 @@ impl RotatingFile {
             .open(active_file_path.clone())?;
         Ok(Self {
             rotation,
-            parent,
             current_file: file,
             index: current_index,
             filename_root: path_str.to_string(),
@@ -241,4 +239,12 @@ pub enum RotationOption {
     SizeMB(u64),
     // SizeLines(u64),
     Duration(Duration),
+}
+/// Enum for possible file prune options.
+#[derive(Debug)]
+
+pub enum PruneMethod {
+    None,
+    MaxFiles(u64),
+    MaxAge(Duration),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ Rotate when a log file exceeds a certain filesize
 ```
 use std::{io::Write, thread::sleep, time::Duration};
 use turnstiles::{RotatingFile, RotationOption, PruneMethod};
-
 use tempdir::TempDir; // Subcrate provided for testing
 let dir = TempDir::new();
 
@@ -153,6 +152,7 @@ impl RotatingFile {
         prune_method: PruneMethod,
         require_newline: bool,
     ) -> Result<Self> {
+        Self::check_options(&rotation_method, &prune_method)?;
         // TODO: throw error if path_str (rootname) ends in digit as this will break the numbering stuff
         let (path_filename, parent) = filename_to_details(path_str)?;
         let active_file_path = format!("{}/{}{}", parent, ACTIVE_PREFIX, path_filename);
@@ -173,6 +173,16 @@ impl RotatingFile {
             active_file_path,
             parent,
         })
+    }
+
+    fn check_options(rotation_method: &RotationOption, prune_method: &PruneMethod) -> Result<()> {
+        if let RotationOption::SizeMB(0) = rotation_method {
+            bail!("Invalid rotation option RotationOption::SizeMB(0)");
+        }
+        if let PruneMethod::MaxFiles(0) = prune_method {
+            bail!("Invalid prune method PruneMethod::MaxFiles(0)");
+        }
+        Ok(())
     }
 
     /// Given a filename stem and folder path, list all files which contain the filename stem.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ use utils::{filename_to_details, safe_unwrap_osstr};
 
 // TODO: template this maybe? Or just make it u128 and fugheddaboutit?
 type FileIndexInt = u32;
-const ACTIVE_PREFIX: &'static str = "ACTIVE_";
+const ACTIVE_PREFIX: &str = "ACTIVE_";
 #[derive(Debug)]
 /// Struct masquerades as a file handle and is written to by whatever you like
 pub struct RotatingFile {
@@ -129,7 +129,7 @@ impl RotatingFile {
             prune_method,
             current_file: file,
             index: current_index,
-            filename_root: path_filename.to_string(),
+            filename_root: path_filename,
             require_newline,
             active_file_path,
             parent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,9 @@ impl RotatingFile {
     fn rotate_current_file(&mut self) -> Result<(), std::io::Error> {
         // TODO: think about if we want to be more careful here, i.e. append to a random file which may already exist and be a totally different format?
         // Could throw an exception, or print a warning and skip that file index. Who logs the loggers...
-        let new_file = &format!("{}.{}", self.filename_root, self.index + 1);
 
+        // TODO: fix naughtyness of renaming file while handle still open, should prob be an option which we take and shutdown
+        let new_file = &format!("{}.{}", self.filename_root, self.index + 1);
         fs::rename(&self.active_file_path, new_file)?;
 
         self.current_file = OpenOptions::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,7 @@ impl RotatingFile {
     }
 
     fn prune_logs(&mut self) -> Result<(), std::io::Error> {
+        // TODO: tidy this horribleness and seek out corner cases
         let log_file_list = Self::list_log_files(&self.filename_root, &self.parent)?;
 
         match self.prune_method {
@@ -234,9 +235,10 @@ impl RotatingFile {
                 }
             }
             PruneMethod::MaxFiles(n) => {
+                let index_u = self.index as usize;
                 // This works but I hate it.
-                if log_file_list.len() > n - 1 {
-                    for i in 1..self.index as usize - n + 2 {
+                if log_file_list.len() > n - 1 && index_u + 2 > 1 + n {
+                    for i in 1..index_u - n + 2 {
                         let file_to_delete = &format!("{}.{}", self.filename_root, i);
 
                         if log_file_list.contains(file_to_delete) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,8 @@ impl RotatingFile {
     pub fn new(path_str: &str, rotation: RotationOption, require_newline: bool) -> Result<Self> {
         // TODO: throw error if path_str (rootname) ends in digit as this will break the numbering stuff
         let (path_filename, parent) = filename_to_details(path_str)?;
-        let current_index = Self::detect_latest_file_index(&path_filename, &parent)? + 1;
         let active_file_path = format!("{}/{}{}", parent, ACTIVE_PREFIX, path_filename);
+        let current_index = Self::detect_latest_file_index(&path_filename, &parent)? + 1;
 
         let file = OpenOptions::new()
             .create(true)
@@ -149,7 +149,7 @@ impl RotatingFile {
         let log_files = Self::list_log_files(filename, folder_path)?;
         let mut max_index = 0;
         for filename_string in log_files {
-            if filename_string == filename {
+            if filename_string == format!("{}{}", ACTIVE_PREFIX, filename) {
                 continue;
             } else {
                 let file_index = match filename_string.split('.').last() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use std::{ffi::OsStr, path::PathBuf};
 pub fn filename_to_details(path_str: &str) -> Result<(String, String)> {
+    // TODO: make this std::io::err as well for consistency?
     let pathbuf = PathBuf::from(path_str);
 
     let filename: String = match pathbuf.file_name() {
@@ -20,9 +21,15 @@ pub fn filename_to_details(path_str: &str) -> Result<(String, String)> {
     Ok((filename, parent))
 }
 
-pub fn safe_unwrap_osstr(s: &OsStr) -> Result<String> {
+pub fn safe_unwrap_osstr(s: &OsStr) -> Result<String, std::io::Error> {
+    // Had just used bail here before but really only can return std::io::Error from all of this stuff...
     let string = match s.to_str() {
-        None => bail!("Could not convert OsStr to &str"),
+        None => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Could not convert OsStr to &str",
+            ))
+        }
         Some(f_str) => f_str.to_string(),
     };
     Ok(string)

--- a/tempdir/src/lib.rs
+++ b/tempdir/src/lib.rs
@@ -1,8 +1,8 @@
-
 /// Code for a TempDir struct to enable creating temporary, randomly named, directories for testing.
 /// Future work: make this an in-mem filesystem instead, maybe?
 use std::{
-    fs::{create_dir_all, remove_dir_all},
+    collections::HashSet,
+    fs::{create_dir_all, read_dir, remove_dir_all},
     iter,
 };
 
@@ -34,4 +34,24 @@ impl Drop for TempDir {
     fn drop(&mut self) {
         self.clear();
     }
+}
+
+// Some helpers
+pub fn get_dir_files_hashset(dir: &str) -> HashSet<String> {
+    let mut files = HashSet::new();
+    for file in read_dir(dir).unwrap() {
+        let filename = file.unwrap().file_name().to_str().unwrap().to_string();
+        files.insert(filename);
+    }
+    files
+}
+
+pub fn assert_correct_files(dir: &str, log_filenames: Vec<&str>) {
+    // TODO: change to ref of vec, prob doesn't need ownership
+    // TODO: fix this complete shitshow
+    let log_files: HashSet<String> = get_dir_files_hashset(dir);
+    let log_files_str: HashSet<&str> = log_files.iter().map(AsRef::as_ref).collect();
+    let expected: HashSet<&str> = log_filenames.into_iter().collect();
+
+    assert_eq!(log_files_str, expected);
 }

--- a/tempdir/src/lib.rs
+++ b/tempdir/src/lib.rs
@@ -1,12 +1,11 @@
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 /// Code for a TempDir struct to enable creating temporary, randomly named, directories for testing.
 /// Future work: make this an in-mem filesystem instead, maybe?
 use std::{
-    collections::HashSet,
-    fs::{create_dir_all, read_dir, remove_dir_all},
+    fs::{create_dir_all, remove_dir_all},
     iter,
 };
-
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+const N_DIR_NAME_CHARS: usize = 7;
 
 /// Temporary directory with a random name. When the struct is dropped, the directory and its contents are deleted
 pub struct TempDir {
@@ -18,7 +17,7 @@ impl TempDir {
         let chars: String = iter::repeat(())
             .map(|()| rng.sample(Alphanumeric))
             .map(char::from)
-            .take(7)
+            .take(N_DIR_NAME_CHARS)
             .collect();
         let path = chars;
         create_dir_all(&path).unwrap();

--- a/tempdir/src/lib.rs
+++ b/tempdir/src/lib.rs
@@ -35,23 +35,3 @@ impl Drop for TempDir {
         self.clear();
     }
 }
-
-// Some helpers
-pub fn get_dir_files_hashset(dir: &str) -> HashSet<String> {
-    let mut files = HashSet::new();
-    for file in read_dir(dir).unwrap() {
-        let filename = file.unwrap().file_name().to_str().unwrap().to_string();
-        files.insert(filename);
-    }
-    files
-}
-
-pub fn assert_correct_files(dir: &str, log_filenames: Vec<&str>) {
-    // TODO: change to ref of vec, prob doesn't need ownership
-    // TODO: fix this complete shitshow
-    let log_files: HashSet<String> = get_dir_files_hashset(dir);
-    let log_files_str: HashSet<&str> = log_files.iter().map(AsRef::as_ref).collect();
-    let expected: HashSet<&str> = log_filenames.into_iter().collect();
-
-    assert_eq!(log_files_str, expected);
-}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,4 @@
 use std::{collections::HashSet, fs, io::Write, thread::sleep, time::Duration};
-
 use tempdir::TempDir;
 use turnstiles::{PruneMethod, RotatingFile, RotationOption};
 
@@ -400,6 +399,35 @@ fn test_file_age_prune() {
     file.write_all(&data).unwrap();
     file.write_all(&data).unwrap();
     assert_correct_files(&dir.path, vec!["ACTIVE_test.log"]);
+}
+
+#[test]
+fn test_invalid_options() {
+    let dir = TempDir::new();
+    let path = &vec![dir.path.clone(), "test.log".to_string()].join("/");
+    assert!(RotatingFile::new(
+        path,
+        RotationOption::SizeMB(1),
+        PruneMethod::MaxAge(Duration::from_millis(1000)),
+        false,
+    )
+    .is_ok());
+
+    assert!(RotatingFile::new(
+        path,
+        RotationOption::SizeMB(0), // not valid
+        PruneMethod::MaxAge(Duration::from_millis(1000)),
+        false,
+    )
+    .is_err());
+
+    assert!(RotatingFile::new(
+        path,
+        RotationOption::SizeMB(1),
+        PruneMethod::MaxFiles(0), // not valid
+        false,
+    )
+    .is_err());
 }
 
 // Some helpers

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -396,8 +396,8 @@ fn test_file_number_prune() {
     )
     .unwrap();
 
-    for i in 0..10 {
-        file.write(&data).unwrap();
+    for _ in 0..10 {
+        file.write_all(&data).unwrap();
     }
 
     assert_correct_files(
@@ -423,12 +423,12 @@ fn test_file_age_prune() {
     )
     .unwrap();
 
-    for i in 0..10 {
-        file.write(&data).unwrap();
+    for _ in 0..10 {
+        file.write_all(&data).unwrap();
     }
     sleep(Duration::from_millis(1000));
-    file.write(&data).unwrap();
-    file.write(&data).unwrap();
+    file.write_all(&data).unwrap();
+    file.write_all(&data).unwrap();
     assert_correct_files(&dir.path, vec!["ACTIVE_test.log".to_string()]);
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -431,7 +431,7 @@ fn test_invalid_options() {
 }
 
 // Some helpers
-pub fn get_dir_files_hashset(dir: &str) -> HashSet<String> {
+fn get_dir_files_hashset(dir: &str) -> HashSet<String> {
     let mut files = HashSet::new();
     for file in fs::read_dir(dir).unwrap() {
         let filename = file.unwrap().file_name().to_str().unwrap().to_string();
@@ -440,7 +440,7 @@ pub fn get_dir_files_hashset(dir: &str) -> HashSet<String> {
     files
 }
 
-pub fn assert_correct_files(dir: &str, log_filenames: Vec<&str>) {
+fn assert_correct_files(dir: &str, log_filenames: Vec<&str>) {
     // TODO: change to ref of vec, prob doesn't need ownership
     // TODO: fix this complete shitshow
     let log_files: HashSet<String> = get_dir_files_hashset(dir);


### PR DESCRIPTION
- Change rotation approach [BREAKING CHANGE] so that the 'current' file is always indicated by an _ACTIVE prefix to the root filename which is renamed to the highest index upon rotation.  This addresses https://github.com/Zylatis/turnstiles/issues/4
-  Add log prune options to avoid filling the disk up (one of the main reasons to have rotation in the first place), addressing https://github.com/Zylatis/turnstiles/issues/5
- Add flag to constructor which enables/disables a requirement that a set of bytes will only be written if it ends in a newline char, which addresses  https://github.com/Zylatis/turnstiles/issues/2. 
- Various tidying things
- Docs/tests