### PR TITLE
Hotfix/fix backwards compat panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turnstiles"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Graeme Gossel <graeme.gossel@gmail.com>"]
 description = "Seamless file rotation"
 edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,10 @@ impl RotatingFile {
         let log_files = Self::list_log_files(filename, folder_path)?;
         let mut max_index = 0;
         for filename_string in log_files {
-            if filename_string == format!("{}{}", ACTIVE_PREFIX, filename) {
+            if filename_string == format!("{}{}", ACTIVE_PREFIX, filename)
+                || filename_string == filename
+            // 2nd condition prevents backwards-incompat-induced panics where we have the old test.log file and it tries to get an int from it
+            {
                 continue;
             } else {
                 let file_index = match filename_string.split('.').last() {


### PR DESCRIPTION
Fixes issue which would cause an error result (and potential panic on unwrap) when running this code for a log dir which was already populated with logs under the old (pre 'active file') regime. Specifically it would try to read the `<rootfilename>.log` and parse the end of it as an integer which would of course fail, so now it just ignores that file when determining highest index which is the old behaviour anyway.