### PR TITLE
Feature/easier wildcards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ slog-async = "2.7.0"
 slog-json = "2.4.0"
 serde = { version = "1.0.130",features = ["derive"]  }
 serde_json = "1.0.68"
+rand = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools::debugging", "filesystem"]
 
 [dependencies]
 anyhow = "1.0"
+regex = "1"
 
 [dev-dependencies]
 tempdir = {path = "tempdir", version = "0.1.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turnstiles"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Graeme Gossel <graeme.gossel@gmail.com>"]
 description = "Seamless file rotation"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are also three options to prune old logs:
 This is currently in active development and may change/break often. Every effort will be taken to ensure that breaking changes that occur are reflected in a change of at least the minor version of the package, both in terms of the API and the generation of log files. Versions prior to 0.2.0 were so riddled with bugs I'm amazed I managed to put my pants on on those days I was writing it.
 
 ## Note:
-Rotation works by keeping track of the 'active' file, the one currently being written to, which upon rotation is renamed to include the next log file index. For example when there is only one log file it will be `test_ACTIVE.log`, which when rotated will get renamed to `test.log.1` and the `test_ACTIVE.log` will represent a new file being written to. Originally no file renaming was done to keep the surface area with the filesystem as small as possible, however this has a few disadvantages and this active-file-approach (courtesy of [flex-logger](https://docs.rs/flexi_logger/latest/flexi_logger/)) was seen as a good compromise.
+Rotation works by keeping track of the 'active' file, the one currently being written to, which upon rotation is renamed to include the next log file index. For example when there is only one log file it will be `test.log.ACTIVE`, which when rotated will get renamed to `test.log.1` and the `test.log.ACTIVE` will represent a new file being written to. Originally no file renaming was done to keep the surface area with the filesystem as small as possible, however this has a few disadvantages and this active-file-approach (courtesy of [flex-logger](https://docs.rs/flexi_logger/latest/flexi_logger/)) was seen as a good compromise. The downside is that the file extension now superifically looks different, but it does mean all logs can be found by simply searching for `test.log*`.
 
 
 # Examples
@@ -48,7 +48,7 @@ assert!(file.index() == 0);
 file.write_all(&data).unwrap();
 assert!(file.index() == 1);
 
-// Now have test_ACTIVE.log and test.log.1
+// Now have test.log.ACTIVE and test.log.1
 ```
 
 Rotate when a log file is too old (based on filesystem metadata timestamps)
@@ -74,7 +74,7 @@ file.write_all(&data).unwrap();
 assert!(file.index() == 1);
 file.write_all(&data).unwrap();
 assert!(file.index() == 1);
-// Will now have test_ACTIVE.log and test.log.1
+// Will now have test.log.ACTIVE and test.log.1
 ```
 
 ## Future work

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,14 +213,11 @@ impl RotatingFile {
         file_regex: &Regex,
         folder_path: &str,
     ) -> Result<Vec<String>, std::io::Error> {
-        // This will exclude active files.
-
         let files = fs::read_dir(&folder_path)?;
 
         let mut log_files = vec![];
         for f in files {
             let filename_str = safe_unwrap_osstr(&f?.file_name())?;
-            // if filename_str.contains(filename) {
             if file_regex.is_match(&filename_str) {
                 log_files.push(filename_str);
             }
@@ -335,6 +332,7 @@ impl RotatingFile {
                 PruneCondition::MaxFiles(n) => {
                     let index_u = self.index as usize;
                     // This works but I hate it; juggling usize stuff
+                    // TODO: invert search to make more performant
                     if log_file_list.len() > n - 1 && index_u + 2 > 1 + n {
                         for i in 1..index_u - n + 2 {
                             let file_to_delete = &format!("{}.{}", self.filename_root, i);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,11 +116,10 @@ for i in 1..4 {
 
 */
 use anyhow::{bail, Result};
-use std::fs::remove_file;
 use std::time::SystemTime;
-use std::{cmp, fs};
 use std::{
-    fs::{File, OpenOptions},
+    cmp,
+    fs::{self, remove_file, File, OpenOptions},
     io,
     time::Duration,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,13 @@ impl RotatingFile {
         folder_path: &str,
     ) -> Result<Vec<String>, std::io::Error> {
         // This will exclude active files.
-        let re = Regex::new(&format!(r"^{}.[0-9]+$", filename)).unwrap();
+        let re = Regex::new(&format!(r"^{}.[0-9]+$", filename)).map_err(|e| {
+            // Thanks I hate it.
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Regex failed with error {}", e),
+            )
+        })?;
         let files = fs::read_dir(&folder_path)?;
 
         let mut log_files = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 /*!
 Library which defines a struct implementing the io::Write trait which will allows file rotation, if applicable, when a file write is done. This works by keeping track
 of the 'active' file, the one currently being written to, which upon rotation is renamed to include the next log file index. For example when there is only one log file it will be
-`test_ACTIVE.log`, which when rotated will get renamed to `test.log.1` and the `test_ACTIVE.log` will represent a new file being written to. Originally no file renaming was done to keep
+`test.log.ACTIVE`, which when rotated will get renamed to `test.log.1` and the `test.log.ACTIVE` will represent a new file being written to. Originally no file renaming was done to keep
 the surface area with the filesystem as small as possible, however this has a few disadvantages and this active-file-approach (courtesy of [flex-logger](https://docs.rs/flexi_logger/latest/flexi_logger/))
-was seen as a good compromise.
+was seen as a good compromise. The downside is that the file extension now superifically looks different, but it does mean all logs can be found by simply searching for `test.log*`.
 
 # Examples
 Rotate when a log file exceeds a certain filesize

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,8 @@ impl RotatingFile {
 
 impl io::Write for RotatingFile {
     fn write(&mut self, bytes: &[u8]) -> Result<usize, std::io::Error> {
-        // Note: to ensure no loss of info we require that the only thing that can return an error from here is the write itself
+        // Note: only the rotate and write methods here can return errors, the errors in prune and rotation_required are suppressed to try ensure max uptime of logging
+        // If rotation_required() fails it will return false so the current file will continue to be written to (or at least, attempted)
 
         if !self.require_newline {
             if self.rotation_required() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -138,26 +138,26 @@ fn test_no_dir_simple() {
     file.write_all(&data).unwrap();
 }
 
-// #[test]
-// #[should_panic]
-// /// Delete directory after initial write, should fail to write again
-// fn test_no_dir_intermediate() {
-//     let dir = TempDir::new();
-//     let path = &vec![dir.path.clone(), "test.log".to_string()].join("/");
+#[test]
+#[should_panic]
+/// Delete directory after initial write, should fail to rotate
+fn test_no_dir_intermediate() {
+    let dir = TempDir::new();
+    let path = &vec![dir.path.clone(), "test.log".to_string()].join("/");
 
-//     let data: Vec<u8> = vec!["a"; 100_000].join("").as_bytes().to_vec();
-//     let mut file = RotatingFile::new(
-//         path,
-//         RotationCondition::Duration(Duration::from_millis(100)),
-//         PruneCondition::None,
-//         false,
-//     )
-//     .unwrap();
-//     file.write_all(&data).unwrap();
-//     sleep(Duration::from_millis(200));
-//     drop(dir);
-//     file.write_all(&data).unwrap();
-// }
+    let data: Vec<u8> = vec!["a"; 100_000].join("").as_bytes().to_vec();
+    let mut file = RotatingFile::new(
+        path,
+        RotationCondition::Duration(Duration::from_millis(100)),
+        PruneCondition::None,
+        false,
+    )
+    .unwrap();
+    file.write_all(&data).unwrap();
+    sleep(Duration::from_millis(200));
+    drop(dir);
+    file.write_all(&data).unwrap();
+}
 
 #[test]
 fn test_data_integrity() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -138,26 +138,26 @@ fn test_no_dir_simple() {
     file.write_all(&data).unwrap();
 }
 
-#[test]
-#[should_panic]
-/// Delete directory after initial write, should fail to write again
-fn test_no_dir_intermediate() {
-    let dir = TempDir::new();
-    let path = &vec![dir.path.clone(), "test.log".to_string()].join("/");
+// #[test]
+// #[should_panic]
+// /// Delete directory after initial write, should fail to write again
+// fn test_no_dir_intermediate() {
+//     let dir = TempDir::new();
+//     let path = &vec![dir.path.clone(), "test.log".to_string()].join("/");
 
-    let data: Vec<u8> = vec!["a"; 100_000].join("").as_bytes().to_vec();
-    let mut file = RotatingFile::new(
-        path,
-        RotationCondition::Duration(Duration::from_millis(100)),
-        PruneCondition::None,
-        false,
-    )
-    .unwrap();
-    file.write_all(&data).unwrap();
-    sleep(Duration::from_millis(200));
-    drop(dir);
-    file.write_all(&data).unwrap();
-}
+//     let data: Vec<u8> = vec!["a"; 100_000].join("").as_bytes().to_vec();
+//     let mut file = RotatingFile::new(
+//         path,
+//         RotationCondition::Duration(Duration::from_millis(100)),
+//         PruneCondition::None,
+//         false,
+//     )
+//     .unwrap();
+//     file.write_all(&data).unwrap();
+//     sleep(Duration::from_millis(200));
+//     drop(dir);
+//     file.write_all(&data).unwrap();
+// }
 
 #[test]
 fn test_data_integrity() {


### PR DESCRIPTION
- Move ACTIVE label from prefix to suffix
- Use regex to match on rotated files
- Suppress errors in prune and rotation condition check to minimize failure cases (if write or rotate fails error will be thrown). Justification: would be shit if permissions changed on an old log and it couldn't be pruned and that made the whole logging system break
